### PR TITLE
Added template for backend.hcl file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 helm_credentials.txt
+backend.hcl
 
 # Ignore helm chart lock files
 Chart.lock

--- a/README.md
+++ b/README.md
@@ -112,3 +112,74 @@ Then later:
  git fetch upstream
  git merge upstream/main  ← (bring in new template changes)
 ```
+
+# 🗂️ Terraform Remote State – MinIO S3
+
+This setup configures Terraform to store state in a private **MinIO** S3 bucket using `backend.hcl`.
+
+---
+
+## 🔧 Backend Details
+
+- **Bucket**: `terraform`  
+- **Key**: `terraform.tfstate`  
+- **Endpoint**: `http://192.168.14.222:9900`  
+- **Auth**: Access key/secret (e.g. `terraform / SuperSecretPassword123`)
+
+---
+
+## 📁 File Structure
+
+```plaintext
+terraform/
+├── backend.hcl     # MinIO S3 backend settings
+├── README.md       # This file
+```
+
+---
+
+## 🚀 Usage
+
+Run from your base module directory:
+
+```bash
+cd base/terraform
+
+terraform init \
+  -backend-config=../../terraform/backend.hcl \
+  -reconfigure
+```
+
+---
+
+## 🧾 backend.hcl Example
+
+```hcl
+bucket                      = "terraform"
+key                         = "terraform.tfstate"
+region                      = "us-east-1"
+
+access_key                  = "terraform"
+secret_key                  = "SuperSecretPassword123"
+endpoints                   = { s3 = "http://192.168.14.222:9900" }
+use_path_style              = true
+
+skip_region_validation      = true
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_requesting_account_id  = true
+```
+
+---
+
+## 🛡️ Tips
+
+- ✅ Use `readwrite` policy in MinIO for the `terraform` user  
+- 🔐 Replace hardcoded creds with env vars for production  
+- 🧪 Validate state with:
+
+  ```bash
+  aws --endpoint-url http://192.168.14.222:9900 s3 ls s3://terraform/
+  ```
+
+---

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 # Thin repo: deploy.sh
 
-# Navigate to the base Terraform directory
+# ————————————————————————————————————————————————
+# 1. Navigate to your base Terraform module
+# ————————————————————————————————————————————————
 cd base/terraform || exit
-terraform init
+
+# ————————————————————————————————————————————————
+# 2. Init Terraform with MinIO S3 backend
+#    -backend-config points at your backend.hcl
+#    -reconfigure forces Terraform to pick up the new backend
+# ————————————————————————————————————————————————
+terraform init \
+  -backend-config="../../terraform/backend.hcl" \
+  -reconfigure
+
+# ————————————————————————————————————————————————
+# 3. Return to repo root
+# ————————————————————————————————————————————————
 cd ../.. || exit
 
 source base/terraform/scripts/nuke-deploy-cluster.sh staging

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,13 +41,7 @@ bash base/scripts/deploy-sealed-secrets.sh
 # Step 2: Deploy sealed secrets used by Helm-based apps
 if [ "$SKIP_HELM_SECRETS" = false ]; then
   echo "🔐 Applying sealed secrets for app deployments..."
-  while IFS= read -r line || [ -n "$line" ]; do
-    # Skip comment and empty lines
-    [[ "$line" =~ ^#.*$ ]] && continue
-    [[ -z "$line" ]] && continue
-    bash base/scripts/generate-sealed-secret.sh "$line"
-  # TODO: Store helm_credentials in bitwarden
-  done < ./secrets/helm_credentials.txt
+  bash base/scripts/secrets/apply-helm-secrets.sh
   echo "✅ All app-related sealed secrets applied!"
 else
   echo "🔁 Skipping Helm-based app sealed secrets deployment because PEM file existed."
@@ -60,10 +54,10 @@ bash base/scripts/deploy-cert-manager.sh
 bash base/scripts/deploy-traefik.sh
 
 # Step 5: Deploy Longhorn
-bash base/scripts/deploy-longhorn.sh
+bash base/scripts/deployments/deploy-longhorn.sh
 
 # Step 6: Deploy Monitoring Tools
-# bash base/scripts/deploy-monitoring.sh
+# bash base/scripts/deployments/deploy-monitoring.sh
 
 # Step X: Deploy TriliumNext
 # bash base/scripts/deploy-trilium.sh
@@ -73,5 +67,14 @@ bash base/scripts/deploy-longhorn.sh
 
 # Step X: Deploy Gitea
 # bash base/scripts/deploy-gitea.sh
+
+# Step X: Deploy Nextcloud
+# bash base/scripts/deployments/deploy-nextcloud.sh
+
+# Step X: Deploy OnlyOffice
+# bash base/scripts/deployments/deploy-nextcloud-onlyoffice.sh
+
+# Step X: Deploy draw.io
+# bash base/scripts/deployments/deploy-nextcloud-drawio.sh
 
 echo "✅ Deployment Completed Successfully!"

--- a/terraform/backend.hcl.template
+++ b/terraform/backend.hcl.template
@@ -1,0 +1,17 @@
+bucket                     = "terraform"
+key                        = "deployment-environment-dev/terraform.tfstate"
+region                     = "us-east-1"
+
+# your MinIO credentials
+access_key                 = "terraform"
+secret_key                 = "superSecret123"
+
+# point at your MinIO endpoint
+endpoints                  = { s3 = "http://192.168.1.222:9900" }
+use_path_style             = true
+
+# disable AWS-only checks/lookups
+skip_region_validation     = true
+skip_credentials_validation= true
+skip_metadata_api_check    = true
+skip_requesting_account_id = true


### PR DESCRIPTION
---

### 🛠️ Add MinIO S3 Remote State Backend for Terraform

This PR adds a templated `backend.hcl` file for storing Terraform state in a MinIO S3 bucket. It also updates the README and deployment scripts to support remote state initialization.

#### Changes:

* Added `backend.hcl.template` with MinIO backend config
* Updated `.gitignore` to exclude `backend.hcl`
* Enhanced `deploy.sh` to initialize Terraform with backend
* Expanded README with setup instructions and usage

---