### PR TITLE
Techdebt/fix slow vm creation

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,7 @@ terraform init \
 # ————————————————————————————————————————————————
 cd ../.. || exit
 
-source base/terraform/scripts/nuke-deploy-cluster.sh staging
+source base/terraform/scripts/nuke-deploy-cluster.sh staging --yes
 
 # Step 1: Handle Sealed Secrets (restore or deploy)
 PEM_FILE="secrets/sealed-secret-controller-cert.pem"
@@ -69,12 +69,12 @@ bash base/scripts/deployments/deploy-longhorn.sh
 # bash base/scripts/deploy-gitea.sh
 
 # Step X: Deploy Nextcloud
-# bash base/scripts/deployments/deploy-nextcloud.sh
+bash base/scripts/deployments/deploy-nextcloud.sh
 
 # Step X: Deploy OnlyOffice
-# bash base/scripts/deployments/deploy-nextcloud-onlyoffice.sh
+bash base/scripts/deployments/deploy-nextcloud-onlyoffice.sh
 
 # Step X: Deploy draw.io
-# bash base/scripts/deployments/deploy-nextcloud-drawio.sh
+bash base/scripts/deployments/deploy-nextcloud-drawio.sh
 
 echo "✅ Deployment Completed Successfully!"

--- a/turn-the-key.sh
+++ b/turn-the-key.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+HOST="192.168.14.231"
+
+# record start time
+start_time=$(date +%s)
+
+echo "🚀 Running prep-server script (this may reboot the host)..."
+bash scripts/prep-server.sh
+
+echo "🔄 Waiting for $HOST to go offline..."
+until ! ping -c1 -W1 "$HOST" &>/dev/null; do
+  sleep 2
+done
+echo "⚠️  $HOST is now offline (reboot in progress)."
+
+echo "🔁 Waiting for $HOST to come back online..."
+until ping -c1 -W1 "$HOST" &>/dev/null; do
+  sleep 2
+done
+echo "✅ $HOST is back online!"
+
+# small buffer before next steps
+sleep 5
+
+echo "▶️  Proceeding with deployment..."
+bash deploy.sh
+
+# record end time and compute elapsed
+end_time=$(date +%s)
+elapsed=$(( end_time - start_time ))
+minutes=$(( elapsed / 60 ))
+seconds=$(( elapsed % 60 ))
+
+echo "⏱ Total elapsed time: ${minutes}m ${seconds}s"


### PR DESCRIPTION
### 🔑 One-Command Cluster Bootstrap + Faster VM Provisioning

This PR introduces a fully automated "turn-the-key" experience for deploying the entire K3s cluster stack from scratch, while also resolving the slow VM creation issue.

---

#### 🆕 New Features

* **`turn-the-key.sh` Script**

  * Provides a **single entry point** for end-to-end cluster deployment.
  * Handles:

    * Running the prep script (including host reboot)
    * Waiting for host availability
    * Executing the full deployment
    * Logging total runtime (e.g., `✅ Deployment Completed Successfully! ⏱ Total elapsed time: 17m 51s`)
  * Ideal for both manual runs and automation.

---

#### ⚡ VM Creation Optimization

* **Externalized Ubuntu Base Image**

  * `transmigrate-ubuntu-server.sh` now downloads and registers a **pre-uncompressed base image** into a dedicated `base-image-pool`.
  * Terraform uses a static path reference (`/var/lib/libvirt/base-images/ubuntu-base-uncompressed.qcow2`) to drastically speed up VM volume creation.

* **Terraform Refactor**

  * Removed base image download from Terraform.
  * Ensured all `base_image` logic now depends on a pre-prepared image outside the plan.

---

#### 🧹 Other Improvements

* **Improved `nuke-deploy-cluster.sh`**

  * Added `--yes` flag for non-interactive mode.
  * Optional backup flow before cluster destruction.

* **Refined `deploy.sh`**

  * Switched to active deployment of:

    * Nextcloud
    * OnlyOffice
    * Draw\.io

* **Cleaned Up Old Scripts**

  * Removed deprecated `deploy-longhorn.sh` and `deploy-monitoring.sh`.

---

With these changes, spinning up a full environment becomes as easy as:

```bash
./turn-the-key.sh
```

> Result: A fully deployed cluster in under 20 minutes, start to finish. 🔥

